### PR TITLE
Add a requirements.txt file for the c2server to specify the pymonocyp…

### DIFF
--- a/c2server/requirements.txt
+++ b/c2server/requirements.txt
@@ -1,0 +1,1 @@
+pymonocypher == 3.1.*


### PR DESCRIPTION
Add a requirements.txt file for the c2server to specify the pymonocypher version.

Version 4 doesn't work as expected, so it's better to make sure version 3 is installed.