### PR TITLE
Fix char delay + jitter type casting bug

### DIFF
--- a/c2server/index.html
+++ b/c2server/index.html
@@ -4694,7 +4694,7 @@
 			return payloadPart + `${padHex(1)}${padHex(mod)}${padHex(hid)}`;
 		};
 		
-		const getHumanized = (delay, jitter) => jitter >= 1 ? delay + Math.floor(Math.random() * jitter) : delay;
+		const getHumanized = (delay, jitter) => Number(jitter) >= 1 ? Number(delay) + Math.floor(Math.random() * Number(jitter)) : Number(delay);
 		
 		function split_process(hexPayload) {
 			const payloadMaxSize = 1008;


### PR DESCRIPTION
I originally raised this bug on [Discord here](https://discord.com/channels/506629366659153951/953129985131040838/1415001635524186263). When using `DEFAULT_CHAR_DELAY_JITTER` each keystroke would take an extremely long time.

It turns out to be a bug in omg.js. I hope this is the right place to edit it. The problem was that char delay and jitter strings were concatenated instead of doing numeric addition. I tested this locally and it works correctly now.